### PR TITLE
feat: Add buttons to refetch dashboard cards

### DIFF
--- a/src/app/dashboard/DashboardClient.jsx
+++ b/src/app/dashboard/DashboardClient.jsx
@@ -2,12 +2,14 @@
 "use client";
 
 import { Suspense } from "react";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { ordersListOptions } from "@/lib/queries/orders";
 import {
   analyticsSummaryOptions,
   slowReportOptions,
 } from "@/lib/queries/analytics";
+import { Button } from "@/components/ui/button";
+import { qk } from "@/lib/query-keys";
 
 // function OrdersCard() {
 //   const { data } = useSuspenseQuery(ordersListOptions({ limit: 5 }));
@@ -25,9 +27,30 @@ function SlowReportCard() {
 }
 
 export default function DashboardClient() {
+  const queryClient = useQueryClient();
   return (
     <>
       <h1>Dashboard</h1>
+      <div className="flex space-x-2">
+        <Button
+          onClick={() =>
+            queryClient.invalidateQueries({
+              queryKey: qk.analytics.summary(),
+            })
+          }
+        >
+          Refetch Summary
+        </Button>
+        <Button
+          onClick={() =>
+            queryClient.invalidateQueries({
+              queryKey: qk.analytics.slowReport(),
+            })
+          }
+        >
+          Refetch Report
+        </Button>
+      </div>
       {/* <Suspense fallback={<p>Loading orders…</p>}>
         <OrdersCard />
       </Suspense> */}


### PR DESCRIPTION
This commit adds two new buttons to the `DashboardClient` component: "Refetch Summary" and "Refetch Report".

- The "Refetch Summary" button, when clicked, invalidates the query for the `SummaryCard`, triggering a data refetch.
- The "Refetch Report" button does the same for the `SlowReportCard`.

This functionality is implemented using the `useQueryClient` hook from `@tanstack/react-query` to invalidate the respective queries.